### PR TITLE
Add a new endpoint

### DIFF
--- a/api/proxy.md
+++ b/api/proxy.md
@@ -32,31 +32,6 @@ Each item in any of those arrays is a project, and follows this format:
 }
 ```
 
-## `/proxy/users`
+## `GET /proxy/users`
 
-### `GET /proxy/users/<name>/activity`
-
-Gets activity events that appear in the user's activity feed. Returns an array of [activity event objects](definitions/activity_event_object.md).
-
-### `GET /proxy/users/<name>/activity/count`
-
-Gets the number of messages the user has, in this format:
-
-```
-{
-    "msg_count": /* Messages the user currently has */
-}
-```
-
-(This endpoint is deprecated in favor of [`/users/<name>/messages/count`](users.md#get-usersusernamemessagescount).)
-
-### `GET /proxy/users/<id>/featured`
-
-Gets projects on the homepage that are featured to user personally. Returns an object of which each of its properties' values are arrays of project objects:
-
-```
-{
-    "custom_projects_by_following": /* Projeted by users the user is following */
-    "custom_projects_loved_by_following": /* Projects loved by users the user is following */
-}
-```
+All of the `/proxy/users` endpoints have been replaced by new endpoints in [/users](users.md).  

--- a/api/proxy.md
+++ b/api/proxy.md
@@ -36,7 +36,7 @@ Each item in any of those arrays is a project, and follows this format:
 
 ### `GET /proxy/users/<name>/activity`
 
-Depreciated.
+This endpoint is deprecated in favor of [`/users/<name>/following/users/activity`](users.md#get-usersusernamefollowingusersactivity).
 
 ### `GET /proxy/users/<name>/activity/count`
 

--- a/api/proxy.md
+++ b/api/proxy.md
@@ -36,7 +36,7 @@ Each item in any of those arrays is a project, and follows this format:
 
 ### `GET /proxy/users/<name>/activity`
 
-Gets activity events that appear in the user's activity feed. Returns an array of [activity event objects](definitions/activity_event_object.md).
+Depreciated.
 
 ### `GET /proxy/users/<name>/activity/count`
 

--- a/api/proxy.md
+++ b/api/proxy.md
@@ -36,7 +36,7 @@ Each item in any of those arrays is a project, and follows this format:
 
 ### `GET /proxy/users/<name>/activity`
 
-Depreciated.
+Gets activity events that appear in the user's activity feed. Returns an array of [activity event objects](definitions/activity_event_object.md).
 
 ### `GET /proxy/users/<name>/activity/count`
 

--- a/api/proxy.md
+++ b/api/proxy.md
@@ -36,7 +36,7 @@ Each item in any of those arrays is a project, and follows this format:
 
 ### `GET /proxy/users/<name>/activity`
 
-This endpoint is deprecated in favor of [`/users/<name>/following/users/activity`](users.md#get-usersusernamefollowingusersactivity).
+Depreciated.
 
 ### `GET /proxy/users/<name>/activity/count`
 

--- a/api/users.md
+++ b/api/users.md
@@ -46,7 +46,7 @@ Gets a list of projects that have recently been shared by users that the given u
 
 ### `GET /users/<username>/following/users/activity`
 
-Gets events that show up in the "What's Happening" feed on the front page.  Returns an array of [activity event objects](definitions/activity_event_object.md).
+Gets events that show up in the "What's Happening" feed on the front page.  Returns an array of [activity event objects](definitions/activity_event_object.md).  [Requires authentication.](../etc/authentication.md)
 
 ### `GET /users/<username>/messages`
 

--- a/api/users.md
+++ b/api/users.md
@@ -46,7 +46,7 @@ Gets a list of projects that have recently been shared by users that the given u
 
 ### `GET /users/<username>/following/users/activity`
 
-Gets activity events that appear in the user's activity feed. Returns an array of [activity event objects](definitions/activity_event_object.md).
+Gets events that show up in the "What's Happening" feed on the front page.  Returns an array of [activity event objects](definitions/activity_event_object.md).
 
 ### `GET /users/<username>/messages`
 

--- a/api/users.md
+++ b/api/users.md
@@ -38,7 +38,7 @@ Gets a list of projects that have recently been added to studios that the given 
 
 ### `GET /users/<username>/following/users/loves`
 
-Gets a list of projects that have recently been loved by users that the given user is following. Returns an array of [project objects](definitions/project_object.md). [Requires authentication.](../etc/authentication.md)
+Gets a list of projects that have recently been loved by users that the given user is following. Shows up as "Projects Loved by Scratchers I'm Following" on the front page.  Returns an array of [project objects](definitions/project_object.md). [Requires authentication.](../etc/authentication.md)
 
 ### `GET /users/<username>/following/users/projects`
 

--- a/api/users.md
+++ b/api/users.md
@@ -44,6 +44,10 @@ Gets a list of projects that have recently been loved by users that the given us
 
 Gets a list of projects that have recently been shared by users that the given user is following. Returns an array of [project objects](definitions/project_object.md). [Requires authentication.](../etc/authentication.md)
 
+### `GET /users/<username>/following/users/activity`
+
+Gets activity events that appear in the user's activity feed. Returns an array of [activity event objects](definitions/activity_event_object.md).
+
 ### `GET /users/<username>/messages`
 
 Gets the content of all messages the user has (including both read and unread ones). Returns an array of [message objects](definitions/message_object.md). [Limited](../etc/limits_and_offsets.md) to 40 results per request. [Requires authentication.](../etc/authentication.md)


### PR DESCRIPTION
### Please ignore the disorganization of this PR; it's been a while 🤔

This pull adds a new endpoint (`GET /users/<username>/following/users/activity`) to `users.md`.  This endpoint lets you get the "What's Happening" feed.  This _does_ require authentication.

(Edit by @towerofnix: Resolves #50, resolves #58.)