### PR TITLE
Add synthesis and translation-service documentation

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -11,6 +11,7 @@ Unofficial documentation for the Scratch API. See [root index](..) for more info
 * [`/proxy` API](proxy.md) - Miscellaneous utilities
 * [`/users` API](users.md) - Fetch user information
 * [`projects.` and `assets.` APIs](project_data.md) - Fetch code and assets used in projects
+* [`synthesis-service.` and `translation-service.` APIs](synth_trans.md) - Fetch translations and syntheses used by block extensions
 
 ### Object definitions
 

--- a/api/project_data.md
+++ b/api/project_data.md
@@ -2,11 +2,15 @@
 
 These retrieve all of the data and files needed for a scratch project/file.
 
-### `GET cdn.projects.scratch.mit.edu/<project id>/`
+## `https://cdn.projects.scratch.mit.edu/`
+
+### `GET /<project id>/`
 
 Retrieves the projects JSON data, which is where all of the code for a scratch project is stored.
 
-### `GET cdn.assets.scratch.mit.edu/internalapi/asset/<md5 file>/get/`
+## `https://cdn.assets.scratch.mit.edu/`
+
+### `GET /internalapi/asset/<md5 file>/get/`
 
 Retrieves the asset with the given file name. An asset is a costume, sound or other file used in a project.  Each asset in each project has a unique md5 id, which is used for referencing and retrieving it. 
 

--- a/api/synth_trans.md
+++ b/api/synth_trans.md
@@ -2,16 +2,22 @@
 
 These retrieve the speech synthesis and translation results for their respective extensions.
 
-Valid `locales` and `speech locales` can be viewed in the Text to Speech extension [source code](https://github.com/scratchfoundation/scratch-vm/blob/489111f4d74909c2adac40ade1618f966ba30c34/src/extensions/scratch3_text2speech/index.js#L194-L341)
-
 ### `GET translate-service.scratch.mit.edu/translate?language=<locale>&text=<text>`
 
-Retrieves the translation of the input text in the given language. Uses Google Translate [as of Dec. 9, 2019](https://scratch.mit.edu/discuss/post/3778811).
+Retrieves the translation of the input text in the given language.
+
+`locale` is generally a two-letter language code. Refer to [this gist](https://gist.github.com/towerofnix/d4369e64604c5a0d7dca94954a83ab35) for a list of supported languages, or check the exports from [`scratch-translate-extension-languages`](https://www.npmjs.com/package/scratch-translate-extension-languages).
+
+Uses Google Translate [as of Dec. 9, 2019](https://scratch.mit.edu/discuss/post/3778811).
 
 ### `GET https://translate-service.scratch.mit.edu/supported`
 
-Retrieves a list of supported language codes for translating text
+Retrieves a list of supported language codes for translating text.
+
+Legacy endpoint - still online, but [no longer used](https://github.com/scratchfoundation/scratch-vm/pull/1159).
 
 ### `GET synthesis-service.scratch.mit.edu/synth?locale=<speech locale>&gender=<gender>&text=<text>`
 
-Retrieves the synthesis of the input text as an audio file. The gender parameter can be either "male" or "female". Likely uses [Amazon Polly](https://aws.amazon.com/polly/).
+Retrieves the synthesis of the input text as an audio file. `gender` is either "male" or "female"; `locale` is a "speech synth locale" as described in [the extension's source code](https://github.com/scratchfoundation/scratch-vm/blob/489111f4d74909c2adac40ade1618f966ba30c34/src/extensions/scratch3_text2speech/index.js#L194-L341).
+
+Likely uses [Amazon Polly](https://aws.amazon.com/polly/).

--- a/api/synth_trans.md
+++ b/api/synth_trans.md
@@ -12,4 +12,4 @@ Retrieves a list of supported language codes for translating text
 
 ### `GET synthesis-service.scratch.mit.edu/synth?locale=<locale>&gender=<gender>&text=<text>`
 
-Retrieves the synthesis of the input text as an audio file. Likely uses Amazon Polly
+Retrieves the synthesis of the input text as an audio file. Likely uses [Amazon Polly](https://aws.amazon.com/polly/)

--- a/api/synth_trans.md
+++ b/api/synth_trans.md
@@ -1,0 +1,11 @@
+# `synthesis-service.` and `translate-service.` APIs
+
+These retrieve the speech synthesis and translation results for their respective extensions.
+
+### `GET translate-service.scratch.mit.edu/translate?language=<language code>&text=<text>`
+
+Retrieves the translation of the input text in the given language. Assumed to use Google Translate
+
+### `GET synthesis-service.scratch.mit.edu/synth?locale=<locale>&gender=<gender>&text=<text>`
+
+Retrieves the synthesis of the input text as an audio file

--- a/api/synth_trans.md
+++ b/api/synth_trans.md
@@ -4,8 +4,12 @@ These retrieve the speech synthesis and translation results for their respective
 
 ### `GET translate-service.scratch.mit.edu/translate?language=<language code>&text=<text>`
 
-Retrieves the translation of the input text in the given language. Assumed to use Google Translate
+Retrieves the translation of the input text in the given language. Uses Google Translate [as of Dec. 9, 2019](https://scratch.mit.edu/discuss/post/3778811).
+
+### `GET https://translate-service.scratch.mit.edu/supported`
+
+Retrieves a list of supported language codes for translating text
 
 ### `GET synthesis-service.scratch.mit.edu/synth?locale=<locale>&gender=<gender>&text=<text>`
 
-Retrieves the synthesis of the input text as an audio file
+Retrieves the synthesis of the input text as an audio file. Likely uses Amazon Polly

--- a/api/synth_trans.md
+++ b/api/synth_trans.md
@@ -2,7 +2,9 @@
 
 These retrieve the speech synthesis and translation results for their respective extensions.
 
-### `GET translate-service.scratch.mit.edu/translate?language=<language code>&text=<text>`
+Valid `locales` and `speech locales` can be viewed in the Text to Speech extension [source code](https://github.com/scratchfoundation/scratch-vm/blob/489111f4d74909c2adac40ade1618f966ba30c34/src/extensions/scratch3_text2speech/index.js#L194-L341)
+
+### `GET translate-service.scratch.mit.edu/translate?language=<locale>&text=<text>`
 
 Retrieves the translation of the input text in the given language. Uses Google Translate [as of Dec. 9, 2019](https://scratch.mit.edu/discuss/post/3778811).
 
@@ -10,6 +12,6 @@ Retrieves the translation of the input text in the given language. Uses Google T
 
 Retrieves a list of supported language codes for translating text
 
-### `GET synthesis-service.scratch.mit.edu/synth?locale=<locale>&gender=<gender>&text=<text>`
+### `GET synthesis-service.scratch.mit.edu/synth?locale=<speech locale>&gender=<gender>&text=<text>`
 
-Retrieves the synthesis of the input text as an audio file. Likely uses [Amazon Polly](https://aws.amazon.com/polly/)
+Retrieves the synthesis of the input text as an audio file. The gender parameter can be either "male" or "female". Likely uses [Amazon Polly](https://aws.amazon.com/polly/).

--- a/api/synth_trans.md
+++ b/api/synth_trans.md
@@ -2,11 +2,11 @@
 
 These retrieve the speech synthesis and translation results for their respective extensions.
 
-### `GET translate-service.scratch.mit.edu/translate?language=<locale>&text=<text>`
+## `https://translate-service.scratch.mit.edu/`
 
-Retrieves the translation of the input text in the given language.
+### `GET /translate?language=<locale>&text=<text>`
 
-`locale` is generally a two-letter language code. Refer to [this gist](https://gist.github.com/towerofnix/d4369e64604c5a0d7dca94954a83ab35) for a list of supported languages, or check the exports from [`scratch-translate-extension-languages`](https://www.npmjs.com/package/scratch-translate-extension-languages).
+Retrieves the translation of the input text in the given language. `locale` is generally a two-letter language code. Refer to [this gist](https://gist.github.com/towerofnix/d4369e64604c5a0d7dca94954a83ab35) for a list of supported languages, or check the exports from [`scratch-translate-extension-languages`](https://www.npmjs.com/package/scratch-translate-extension-languages).
 
 Uses Google Translate [as of Dec. 9, 2019](https://scratch.mit.edu/discuss/post/3778811).
 
@@ -16,8 +16,10 @@ Retrieves a list of supported language codes for translating text.
 
 Legacy endpoint - still online, but [no longer used](https://github.com/scratchfoundation/scratch-vm/pull/1159).
 
-### `GET synthesis-service.scratch.mit.edu/synth?locale=<speech locale>&gender=<gender>&text=<text>`
+## `https://synthesis-service.scratch.mit.edu/`
 
-Retrieves the synthesis of the input text as an audio file. `gender` is either "male" or "female"; `locale` is a "speech synth locale" as described in [the extension's source code](https://github.com/scratchfoundation/scratch-vm/blob/489111f4d74909c2adac40ade1618f966ba30c34/src/extensions/scratch3_text2speech/index.js#L194-L341).
+### `GET /synth?locale=<speech locale>&gender=<gender>&text=<text>`
+
+Retrieves the synthesis of the input text as an audio file. `gender` is either "male" or "female"; `speech locale` is a "speech synth locale" as described in [the extension's source code](https://github.com/scratchfoundation/scratch-vm/blob/489111f4d74909c2adac40ade1618f966ba30c34/src/extensions/scratch3_text2speech/index.js#L194-L341).
 
 Likely uses [Amazon Polly](https://aws.amazon.com/polly/).


### PR DESCRIPTION
These are a couple of small internal APIs, but I think they are worth documenting for reverse-engineering purposes :)