### PR TITLE
Remove number of comments in Project object

### DIFF
--- a/api/definitions/project_object.md
+++ b/api/definitions/project_object.md
@@ -21,7 +21,6 @@ A project object looks like this:
         "modified": /* The timestamp of the last time the project was modified */
     }
     "stats": {
-        "comments": /* The number of comments the project has */
         "loves": /* The number of love-its the project has */
         "favorites": /* The number of favorites the project has */
         "views": /* The number of views the project has */


### PR DESCRIPTION
The API does not seem to return the number of comments anymore.
For example, try: https://api.scratch.mit.edu/projects/155273148

