### PR TITLE
Fix link issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*(Quick links to: [/api/ API reference](https://towerofnix.github.io/https://towerofnix.github.io/scratch-api-unofficial-docs/api/), [/etc/ additional documentation](https://towerofnix.github.io/scratch-api-unofficial-docs/etc/).)*
+*(Quick links to: [/api/ API reference](https://towerofnix.github.io/scratch-api-unofficial-docs/api/), [/etc/ additional documentation](https://towerofnix.github.io/scratch-api-unofficial-docs/etc/).)*
 
 Welcome to the Scratch API Unofficial Documentation! This wiki is an organized place to put all the information the community has gathered about the new Scratch API.
 


### PR DESCRIPTION
The link is misspelled leading to the user clicking the wrong URL: https://towerofnix.github.io/https://towerofnix.github.io/scratch-api-unofficial-docs/api/. The right one is https://towerofnix.github.io/scratch-api-unofficial-docs/api/